### PR TITLE
Fix missing import

### DIFF
--- a/eval-in-repl-slime.el
+++ b/eval-in-repl-slime.el
@@ -34,6 +34,7 @@
 ;;; Require dependencies
 (require 'eval-in-repl)
 (require 'slime)
+(require 'slime-repl)
 
 
 ;;;


### PR DESCRIPTION
'slime-switch-to-output-buffer'  and 'slime-repl-return' are defined
in slime-repl.el.

I got following byte compile warnings with original code.

```
In end of data:
eval-in-repl-slime.el:74:1:Warning: the following functions are not known to be defined:
    slime-switch-to-output-buffer, slime-repl-return
```
