### PR TITLE
Added optional argument to not move to next statement in eir-eval-in-shell

### DIFF
--- a/eval-in-repl-shell.el
+++ b/eval-in-repl-shell.el
@@ -57,11 +57,12 @@
 
 ;;; eir-eval-in-shell
 ;;;###autoload
-(defun eir-eval-in-shell ()
+(defun eir-eval-in-shell (&optional no-jump-after-eval-p)
   "eval-in-repl for shell."
   (interactive)
   ;; Define local variables
-  (let* ((script-window (selected-window)))
+  (let* ((script-window (selected-window))
+         (initial-point (point)))
     ;;
     (eir-repl-start "\\*shell\\*" #'shell)
 
@@ -82,8 +83,12 @@
 	  (eir-send-to-shell (buffer-substring-no-properties (point) (mark)))
 	;; If empty, deselect region
 	(setq mark-active nil))
-      ;; Move to the next statement
-      (essh-next-code-line)
+
+      ;; Move to the next statement unless told not to
+      (if (not no-jump-after-eval-p)
+          (essh-next-code-line)
+        ;; Go back to the initial position otherwise
+        (goto-char initial-point))
 
       ;; Switch to the shell
       (switch-to-buffer-other-window "*shell*")


### PR DESCRIPTION
In shell scripts, sometimes I want to eval and move on to the next statement. But sometimes I don't want the point to move. This solution adds an optional argument to eir-eval-in-shell. That way, one can set up a second key binding to eval and stay in place, instead of to move on. For example like this:

```elisp
(add-hook 'sh-mode-hook
          '(lambda ()
             (local-set-key (kbd "C-M-<return>") (lambda ()
                                                   (interactive)
                                                   (eir-eval-in-shell t)))))
```

I am a total Elisp beginner. Please let me know if you think there is a better way to accomplish this!