### PR TITLE
Sets exec-in-script to t for shell

### DIFF
--- a/eval-in-repl-shell.el
+++ b/eval-in-repl-shell.el
@@ -57,7 +57,7 @@
   (let* (;; Save current point
 	 (initial-point (point)))
     ;;
-    (eir-repl-start "\\*shell\\*" #'shell)
+    (eir-repl-start "\\*shell\\*" #'shell t)
 
     ;; Check if selection is present
     (if (and transient-mark-mode mark-active)


### PR DESCRIPTION
Addresses #17 and #21 -- at least for me. Most other languages have `exec-in-script` to true, not sure why this is not the case for python and shell functions as well? When I set this to `t` then all works as expected with no other modifications to the code.