### PR TITLE
Add elm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ The following files are included in the package. There are respective dependenci
 - eval-in-repl-iex.el (depends on elixir-mode.el, and alchemist.el)
  - Support for Elixir via alchemist.el
 
+- eval-in-repl-erlang.el (depends on erlang.el)
+ - Support for Erlang via erlang.el
+
 **Configuration**
 --------------------
 
@@ -254,6 +257,11 @@ configuration when invoked to evaluate a line."
 ;; (require 'alchemist)   ; if not done elsewhere
 (require 'eval-in-repl-ruby)
 (define-key elixir-mode-map (kbd "<C-return>") 'eir-eval-in-iex)
+
+;;; Erlang support
+;; (require 'erlang-mode) ; if not done elsewhere
+(require 'eval-in-repl-erlang)
+(define-key erlang-mode-map (kbd "<C-return>") 'eir-eval-in-erlang)
 ```
 
 **Known issues**

--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ The following files are included in the package. There are respective dependenci
 - eval-in-repl-erlang.el (depends on erlang.el)
  - Support for Erlang via erlang.el
 
+- eval-in-repl-elm.el (depends on elm-mode.el)
+ - Support for Elm via elm-mode.el
+
 **Configuration**
 --------------------
 
@@ -262,6 +265,11 @@ configuration when invoked to evaluate a line."
 ;; (require 'erlang-mode) ; if not done elsewhere
 (require 'eval-in-repl-erlang)
 (define-key erlang-mode-map (kbd "<C-return>") 'eir-eval-in-erlang)
+
+;;; Elm support
+;; (require 'elm-mode) ; if not done elsewhere
+(require 'eval-in-repl-elm)
+(define-key elm-mode-map (kbd "<C-return>") 'eir-eval-in-elm)
 ```
 
 **Known issues**

--- a/eval-in-repl-elm.el
+++ b/eval-in-repl-elm.el
@@ -1,0 +1,88 @@
+;;; eval-in-repl-elm.el --- ESS-like eval for Elm  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2017  Terje Larsen, Kazuki YOSHIDA
+
+;; Author: Terje Larsen <terlar@gmail.com>, Kazuki YOSHIDA <kazukiyoshida@mail.harvard.edu>
+;; Keywords: tools, convenience
+;; URL: https://github.com/kaz-yos/eval-in-repl
+;; Version: 0.9.6
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+;;; Commentary:
+
+;; elm-mode.el-specific file for eval-in-repl
+;; See below for configuration
+;; https://github.com/kaz-yos/eval-in-repl/
+
+
+;;; Code:
+
+;;;
+;;; Require dependencies
+(require 'eval-in-repl)
+(require 'elm-mode)
+
+
+;;;
+;;; ELM-MODE RELATED
+;;; eir-send-to-elm
+(defalias 'eir-send-to-elm
+  (apply-partially 'eir-send-to-repl
+                   ;; fun-change-to-repl
+                   #'(lambda () (switch-to-buffer-other-window "*elm*"))
+                   ;; fun-execute
+                   #'comint-send-input)
+  "Send expression to *elm* and have it evaluated.")
+
+
+;;; eir-eval-in-elm
+;;;###autoload
+(defun eir-eval-in-elm ()
+  "Provides eval-in-repl for Elm."
+  (interactive)
+  ;; Define local variables
+  (let* (;; Save current point
+	     (initial-point (point)))
+
+    (eir-repl-start "\\*elm\\*" #'elm-repl-load t)
+
+    ;; Check if selection is present
+    (if (and transient-mark-mode mark-active)
+	    ;; If selected, send region
+	    (eir-send-to-elm (buffer-substring-no-properties (point) (mark)))
+
+      ;; If not selected, do all the following
+      ;; Move to the beginning of line
+      (beginning-of-line)
+      ;; Set mark at current position
+      (set-mark (point))
+      ;; Go to the end of line
+      (end-of-line)
+      ;; Send region if not empty
+      (if (not (equal (point) (mark)))
+	      (eir-send-to-elm (buffer-substring-no-properties (point) (mark)))
+	    ;; If empty, deselect region
+	    (setq mark-active nil))
+
+      ;; Move to the next statement code if jumping
+      (if eir-jump-after-eval
+          (eir-next-code-line)
+        ;; Go back to the initial position otherwise
+        (goto-char initial-point)))))
+
+
+(provide 'eval-in-repl-elm)
+;;; eval-in-repl-elm.el ends here

--- a/eval-in-repl-erlang.el
+++ b/eval-in-repl-erlang.el
@@ -1,0 +1,88 @@
+;;; eval-in-repl-erlang.el --- ESS-like eval for Erlang  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2017  Terje Larsen, Kazuki YOSHIDA
+
+;; Author: Terje Larsen <terlar@gmail.com>, Kazuki YOSHIDA <kazukiyoshida@mail.harvard.edu>
+;; Keywords: tools, convenience
+;; URL: https://github.com/kaz-yos/eval-in-repl
+;; Version: 0.9.6
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+;;; Commentary:
+
+;; erlang.el-specific file for eval-in-repl
+;; See below for configuration
+;; https://github.com/kaz-yos/eval-in-repl/
+
+
+;;; Code:
+
+;;;
+;;; Require dependencies
+(require 'eval-in-repl)
+(require 'erlang)
+
+
+;;;
+;;; ERLANG-MODE RELATED
+;;; eir-send-to-erlang
+(defalias 'eir-send-to-erlang
+  (apply-partially 'eir-send-to-repl
+                   ;; fun-change-to-repl
+                   #'erlang-shell-display
+                   ;; fun-execute
+                   #'comint-send-input)
+  "Send expression to *erlang* and have it evaluated.")
+
+
+;;; eir-eval-in-erlang
+;;;###autoload
+(defun eir-eval-in-erlang ()
+  "Provides eval-in-repl for Erlang."
+  (interactive)
+  ;; Define local variables
+  (let* (;; Save current point
+	     (initial-point (point)))
+
+    (eir-repl-start "\\*erlang\\*" #'erlang-shell-display t)
+
+    ;; Check if selection is present
+    (if (and transient-mark-mode mark-active)
+	    ;; If selected, send region
+	    (eir-send-to-erlang (buffer-substring-no-properties (point) (mark)))
+
+      ;; If not selected, do all the following
+      ;; Move to the beginning of line
+      (beginning-of-line)
+      ;; Set mark at current position
+      (set-mark (point))
+      ;; Go to the end of line
+      (end-of-line)
+      ;; Send region if not empty
+      (if (not (equal (point) (mark)))
+	      (eir-send-to-erlang (buffer-substring-no-properties (point) (mark)))
+	    ;; If empty, deselect region
+	    (setq mark-active nil))
+
+      ;; Move to the next statement code if jumping
+      (if eir-jump-after-eval
+          (eir-next-code-line)
+        ;; Go back to the initial position otherwise
+        (goto-char initial-point)))))
+
+
+(provide 'eval-in-repl-erlang)
+;;; eval-in-repl-erlang.el ends here


### PR DESCRIPTION
Sorry about the extra commit, since I based this on top of the Erlang one. But should disappear after that one is merged.

I was thinking perhaps some of this shared logic could be extracted out to reduce the duplicated code among these kind of eval REPL implementations.