### PR TITLE
Add support for MIT scheme in Geiser REPL

### DIFF
--- a/eval-in-repl-geiser.el
+++ b/eval-in-repl-geiser.el
@@ -55,7 +55,7 @@
   (interactive)
   (eir-eval-in-repl-lisp
    ;; repl-buffer-regexp
-   "\\* Racket REPL.*\\*$\\|\\* Guile REPL.*\\*$"
+   "\\* Racket REPL.*\\*$\\|\\* Guile REPL.*\\*$\\|\\* Mit REPL.*\\*$"
    ;; fun-repl-start
    #'run-geiser
    ;; fun-repl-send


### PR DESCRIPTION
This PR fixes an issue where each use of "eval-in-repl-geiser" in an MIT scheme Geiser source buffer creates a new MIT Geiser REPL buffer, rather than evaluating in the existing MIT Geiser REPL buffer. The MIT scheme REPL now behaves as it does for racket and guile, using the same REPL buffer. 

This is done by extending the "repl-buffer-regexp". Now that Geiser has support for other schemes such as chicken, chez, gambit etc., the regexp could presumably be extended to them as well

Signed-off-by: Jason Cairns <jcai849@aucklanduni.ac.nz>