### PR TITLE
Prevent dynamic changing of vterm buffer name

### DIFF
--- a/eval-in-repl-shell.el
+++ b/eval-in-repl-shell.el
@@ -84,7 +84,10 @@
 (cl-defmethod eir-create-shell (shell-name &context (eir-shell-type (eql vterm)))
   ;; vterm messes with the window configuration
   (save-window-excursion
-    (vterm shell-name)))
+    ;; Start vterm, and force buffer name to stay shell-name (in case
+    ;; when vterm-buffer-name-string is customized)
+    (with-current-buffer (vterm shell-name)
+      (setq-local vterm-buffer-name-string nil))))
 
 ;;; eir-eval-in-shell
 ;;;###autoload


### PR DESCRIPTION
When an user customizes vterm-buffer-name-string to be non-nil, vterm
buffer names can change dynamically, depending, for example, on the
working directory of the shell. This causes problems in eval-in-repl,
which assumes that the buffer names does not change and is always
equal to eir-shell-buffer-name. Specifically, each call to
eir-eval-in-shell causes a new buffer to be created.

This change prevents the dynamic name changes for vterm buffers
created by eval-in-repl.